### PR TITLE
fix data function to handle multi path segments

### DIFF
--- a/src/helpers/common.ts
+++ b/src/helpers/common.ts
@@ -49,8 +49,10 @@ export const toNewData = liftedReplace([
  *
  * returns the _value_ (aka, `data.val()`) of the current database path
  */
-export const data = (child?: string) =>
-  `data.${child ? `child('${child}').` : ""}val()`;
+export const data = (path?: string): string => {
+  const segments: string[] = path.split('/')
+  return `data.${segments.map(s => `child(${s})`).join('.')}.val()`
+}
 
 /**
  * returns the _value_ of the **new** data at the current database path

--- a/src/helpers/common.ts
+++ b/src/helpers/common.ts
@@ -51,7 +51,7 @@ export const toNewData = liftedReplace([
  */
 export const data = (path?: string): string => {
   const segments: string[] = path.split('/')
-  return `data.${segments.map(s => `child(${s})`).join('.')}.val()`
+  return `data.${segments.map(s => `child('${s}')`).join('.')}.val()`
 }
 
 /**


### PR DESCRIPTION
Make `data('foo/bar')` return `data.child('foo').child('bar').val()` instead of `data.child('foo/bar').val()`